### PR TITLE
Modifications for 16.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,13 @@ Optional. If set to "lite", the lite version of the vPFE is used, even if
 the CPU would allow the use of the high performance vPFE image from the
 provided vMX distribution tar file.
 
+--env VCPMEM="<megabytes>"
+Optional. set the amount of memeory in MB given to the vRE image.
+default is 2000 (16.1F requires only 1G).  
+
 --env MEM="<megabytes>"   
 Optional. Set the amount of memory in MB given to the vPFE image.
-default is 8000 (15.1F requires at least 8GB). The vRE image is hard set in launch.sh to 2000MB.
+default is 8000 (15.1F requires at least 8GB).
 
 --env VCPU="<count>"  
 Optional. Set the number of vCPU to be used by the vPFE. Default is 5.

--- a/run-vmx1.sh
+++ b/run-vmx1.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
-docker run --name vmx1 --rm --privileged --net=host \
+sudo docker run --name vmx1 --rm --privileged --net=host \
   -v $PWD:/u:ro \
-  --env TAR="vmx-15.1F3.11.tgz" \
+  --env TAR="vmx-bundle-16.1R2.11.tgz" \
   --env CFG="vmx1.cfg" \
-  --env CONFIG="vmx1.conf.txt" \
   --env DEV="br0 br0" \
-  --env MEM="8000" --env VCPU="7" \
+  --env VCPMEM="1000" \
+  --env MEM="4000" \
+  --env VCPU="3" \
   -i -t marcelwiget/vmx:latest


### PR DESCRIPTION
Bugs:

- Fixed: path checking for VCP Image - As for 16.1 junos*qcow2 is used and not jinstall64*img.
- Fixed: handling of ls aborting - Now checking only empty string; without, script abording at ls exit code.

Features:

- Added VCPMEM for handling vRE MEM - From 16.1, 1GB can be used (no fix 2GB needed). Default will still be 2GB
- Edited README for first feature.
- Edited run-vmx1.sh for first feature.